### PR TITLE
197 synccenter

### DIFF
--- a/api/UnifiedHandlerClient.ts
+++ b/api/UnifiedHandlerClient.ts
@@ -1,4 +1,3 @@
-import jwtDecode from "jwt-decode"
 import { io } from "socket.io-client"
 import axios from "axios"
 import rdiff from "recursive-diff"
@@ -6,14 +5,13 @@ import { UnifiedHandlerCore } from "./UnifiedHandlerCore"
 import {
     cache_item,
     non_file_meta_value,
-    profile,
     profile_seed,
     profiles_sync_package,
     thing,
     user,
 } from "./UnifiedHandler_types"
 import { useNavigate } from "react-router-dom"
-import { OutputData, SavedData } from "@editorjs/editorjs/types/data-formats"
+import { OutputData } from "@editorjs/editorjs/types/data-formats"
 import { getRandomSubarray } from "./utils"
 var { applyDiff } = rdiff
 
@@ -22,7 +20,10 @@ export class UnifiedHandlerClient extends UnifiedHandlerCore {
     websocket_api_endpoint: string
     restful_api_endpoint: string
     profiles_seed: profile_seed[] = []
-    profiles_sync_package?: profiles_sync_package = undefined
+    profiles_sync_package?: profiles_sync_package = {
+        transactions: [],
+        profiles: [],
+    }
     strings: (Function | string)[]
     constructor(
         websocket_api_endpoint: string,
@@ -69,6 +70,7 @@ export class UnifiedHandlerClient extends UnifiedHandlerCore {
             }
         )
     }
+
     onChange() {
         for (var func of Object.values(this.onChanges)) {
             func()

--- a/api/UnifiedHandlerCore.ts
+++ b/api/UnifiedHandlerCore.ts
@@ -70,7 +70,7 @@ export class UnifiedHandlerCore {
         this.onChanges.time_travel_snapshot()
         this.onChanges.cache()
     }
-
+    
     transactions: transaction[] = []
 
     get cache(): cache_item<thing>[] {

--- a/api/UnifiedHandlerCore.ts
+++ b/api/UnifiedHandlerCore.ts
@@ -1,5 +1,6 @@
 //read README file : UnifiedHandlerSystem.md
 
+import { custom_find_unique } from "../common_helpers.js"
 import { cache_item, thing, transaction } from "./UnifiedHandler_types.js"
 import {
     calc_cache,
@@ -27,6 +28,27 @@ export class UnifiedHandlerCore {
             .flat()
     find_thing_meta = (thing_id: number) =>
         find_thing_meta(this.cache, thing_id)
+    apply_max_sync_depth(
+        transactions: transaction[],
+        max_sync_depth: number | undefined
+    ): transaction[] {
+        if (max_sync_depth === undefined) {
+            return transactions
+        }
+        var result: transaction[] = []
+        custom_find_unique(
+            transactions.map((tr) => tr.thing_id),
+            (i1: number, i2: number) => i1 === i2
+        ).forEach((unique_thing_id) => {
+            var clone = transactions.filter(
+                (tr) => tr.thing_id === unique_thing_id
+            )
+            clone.reverse()
+            result.push(...clone.slice(0, max_sync_depth))
+        })
+        result.sort((tr1, tr2) => tr1.id - tr2.id)
+        return result
+    }
     new_transaction_privileges_check = new_transaction_privileges_check
     extract_user_id = extract_user_id
     check_lock = check_lock

--- a/api/UnifiedHandlerServer.ts
+++ b/api/UnifiedHandlerServer.ts
@@ -784,8 +784,7 @@ export class UnifiedHandlerServer extends UnifiedHandlerCore {
 
         websocket_client.socket.emit(
             "sync_all_transactions",
-            this.calc_all_discoverable_transactions(current)
-            .filter(
+            this.calc_all_discoverable_transactions(current).filter(
                 (tr) =>
                     websocket_client.cached_transaction_ids.includes(tr.id) ===
                     false
@@ -836,8 +835,12 @@ export class UnifiedHandlerServer extends UnifiedHandlerCore {
                 console.error(error)
             }
         })
-        socket.on("sync_cache", (transaction_ids: transaction["id"][]) => {
-            new_websocket_client.cached_transaction_ids = transaction_ids
-        })
+        socket.on(
+            "sync_cache",
+            (transaction_ids: transaction["id"][], callback) => {
+                new_websocket_client.cached_transaction_ids = transaction_ids
+                callback()
+            }
+        )
     }
 }

--- a/api/UnifiedHandlerServer.ts
+++ b/api/UnifiedHandlerServer.ts
@@ -731,27 +731,7 @@ export class UnifiedHandlerServer extends UnifiedHandlerCore {
 
         return transaction.thing_id
     }
-    apply_max_sync_depth(
-        transactions: transaction[],
-        max_sync_depth: number | undefined
-    ): transaction[] {
-        if (max_sync_depth === undefined) {
-            return transactions
-        }
-        var result: transaction[] = []
-        custom_find_unique(
-            transactions.map((tr) => tr.thing_id),
-            (i1: number, i2: number) => i1 === i2
-        ).forEach((unique_thing_id) => {
-            var clone = transactions.filter(
-                (tr) => tr.thing_id === unique_thing_id
-            )
-            clone.reverse()
-            result.push(...clone.slice(0, max_sync_depth))
-        })
-        result.sort((tr1, tr2) => tr1.id - tr2.id)
-        return result
-    }
+
     calc_profile(
         profile_seed: profile_seed,
         transaction_limit: number | undefined

--- a/api/UnifiedHandler_types.ts
+++ b/api/UnifiedHandler_types.ts
@@ -153,13 +153,17 @@ export interface websocket_client {
     last_synced_snapshot: number | undefined /*  a transaction_id  */
 }
 export type profile_data = {
-    transactions: transaction[]
+    discoverable_for_this_user: transaction["id"][]
 }
 export type profile_seed = {
     user_id: number
     jwt?: string
     is_active: boolean
+    max_depth?: number
 }
 export type profile = profile_data & profile_seed
-export type profiles = profile[]
+export type profiles_sync_package = {
+    profiles: profile[]
+    transactions: transaction[]
+}
 export type complete_diff = { path: string[]; after: any; before: any }[]

--- a/api/UnifiedHandler_types.ts
+++ b/api/UnifiedHandler_types.ts
@@ -150,6 +150,7 @@ export interface websocket_client {
     socket: Socket
     profiles_seed?: profile_seed[]
     prev_profiles_seed?: profile_seed[]
+    cached_transaction_ids: transaction["id"][]
     last_synced_snapshot: number | undefined /*  a transaction_id  */
 }
 export type profile_data = {
@@ -162,8 +163,5 @@ export type profile_seed = {
     max_depth?: number
 }
 export type profile = profile_data & profile_seed
-export type profiles_sync_package = {
-    profiles: profile[]
-    transactions: transaction[]
-}
+
 export type complete_diff = { path: string[]; after: any; before: any }[]

--- a/src/Dashboard.jsx
+++ b/src/Dashboard.jsx
@@ -5,22 +5,22 @@ import { useNavigate } from "react-router-dom"
 import "react-contexify/ReactContexify.css"
 import { UnifiedHandlerClientContext } from "./UnifiedHandlerClientContext"
 import { Calendar } from "primereact/calendar"
-import { InputSwitch } from "primereact/inputswitch"
 import {
     CustomTabMenu,
     Feed,
     NewUnitShortcuts,
     MetroButton,
+    SyncCentreWidget,
 } from "./components/DashboardParts"
 import { ProfilesSlideMenu } from "./components/DashboardParts"
 import { Button } from "primereact/button"
 import { Panel } from "primereact/panel"
-import { InputNumber } from "primereact/inputnumber"
+import { VirtualLocalStorageContext } from "./VirtualLocalStorageContext"
 
 export function Dashboard() {
-    var { cache } = useContext(UnifiedHandlerClientContext)
+    var { cache, strings } = useContext(UnifiedHandlerClientContext)
+
     var [date, setDate] = useState()
-    var { strings } = useContext(UnifiedHandlerClientContext)
     var nav = useNavigate()
     return (
         <>
@@ -46,60 +46,9 @@ export function Dashboard() {
                             text="My Active Profile"
                             link={`/${uhc.user_id}`}
                         />
-
-                        <Panel
-                            className="h-full"
-                            header={
-                                <div className="flex space-x-2">
-                                    <i
-                                        className={`bi-clock-history font-bold`}
-                                    />
-                                    <span>Sync Centre</span>
-                                </div>
-                            }
-                        >
-                            <p>
-                                you have access to ${cache.length} things over
-                                the network. some of them may have hundereds or
-                                thousands of changes from their beginning. "max
-                                depth" is maximum number of changes you want to
-                                fetch for each thing. minimum is 1 which means
-                                you just want to be synced with latest change of
-                                those things.
-                            </p>
-
-                            <label
-                                htmlFor="max_sync_depth_undefined"
-                                className="font-bold block mb-2"
-                            >
-                                sync without limit
-                            </label>
-
-                            <InputSwitch
-                                inputId="max_sync_depth_undefined"
-                                checked={uhc.max_sync_depth === undefined}
-                                onChange={(e) =>
-                                    (uhc.max_sync_depth =
-                                        e.value === true ? undefined : 10)
-                                }
-                            />
-
-                            <label
-                                htmlFor="max_depth"
-                                className="font-bold block mb-2"
-                            >
-                                Max Sync Depth
-                            </label>
-                            <InputNumber
-                                min={1}
-                                inputId="max_depth"
-                                value={uhc.max_sync_depth}
-                                onValueChange={(e) =>
-                                    (uhc.max_sync_depth = e.value)
-                                }
-                            />
-                        </Panel>
+                        <SyncCentreWidget />
                     </div>
+
                     <div className="col-span-full col-start-2 row-start-1 row-span-full">
                         <Feed />
                     </div>

--- a/src/UnifiedHandlerClientContextProvider.jsx
+++ b/src/UnifiedHandlerClientContextProvider.jsx
@@ -4,9 +4,8 @@ import { UnifiedHandlerClient } from "../api_dist/api/UnifiedHandlerClient"
 import { VirtualLocalStorageContext } from "./VirtualLocalStorageContext"
 import translation_packs from "./translation_packs"
 export const UnifiedHandlerClientContextProvider = ({ children }) => {
-    var { profiles_seed, lang, set_virtual_local_storage } = useContext(
-        VirtualLocalStorageContext
-    )
+    var { profiles_seed, lang, set_virtual_local_storage, all_transactions } =
+        useContext(VirtualLocalStorageContext)
 
     var [
         UnifiedHandlerClientContextState,
@@ -38,8 +37,23 @@ export const UnifiedHandlerClientContextProvider = ({ children }) => {
     }
     useEffect(() => {
         window.uhc.profiles_seed = profiles_seed
-        window.uhc.sync_profiles_seed()
+        window.uhc.all_transactions = all_transactions
+        window.uhc.sync_cache().then(
+            () => window.uhc.sync_profiles_seed(),
+            () => {
+                throw "sync cache failed"
+            }
+        )
     }, [profiles_seed])
+    useEffect(() => {
+        set_virtual_local_storage((prev) => ({
+            ...prev,
+            all_transactions: window.uhc.all_transactions,
+        }))
+    }, [UnifiedHandlerClientContextState.transactions])
+    useEffect(() => {
+        window.uhc.sync_cache()
+    }, [all_transactions])
     useEffect(() => {
         window.uhc.strings = translation_packs[lang]
         setUnifiedHandlerClientContextState((prev) => ({

--- a/src/UnifiedHandlerClientContextProvider.jsx
+++ b/src/UnifiedHandlerClientContextProvider.jsx
@@ -38,7 +38,7 @@ export const UnifiedHandlerClientContextProvider = ({ children }) => {
     }
     useEffect(() => {
         window.uhc.profiles_seed = profiles_seed
-        window.uhc.sync_profiles()
+        window.uhc.sync_profiles_seed()
     }, [profiles_seed])
     useEffect(() => {
         window.uhc.strings = translation_packs[lang]

--- a/src/VirtualLocalStorageContextProvider.jsx
+++ b/src/VirtualLocalStorageContextProvider.jsx
@@ -25,10 +25,20 @@ export const VirtualLocalStorageContextProvider = ({ children }) => {
         JSON.parse(window.localStorage.getItem("app_data"))
     )
     useEffect(() => {
-        window.localStorage.setItem(
-            "app_data",
-            JSON.stringify(virtual_local_storage)
-        )
+        try {
+            window.localStorage.setItem(
+                "app_data",
+                JSON.stringify(virtual_local_storage)
+            )
+        } catch (error) {
+            console.log(error)
+            alert(
+                "warning : when tried to write new value of this to localStorage an error happened : virtual local storage context state."
+            )
+            alert(
+                "it doesnt cause any problem but maybe any new try to sync state to disk fail. contact us to fix it. more info is in console"
+            )
+        }
     }, [virtual_local_storage])
 
     return (

--- a/src/VirtualLocalStorageContextProvider.jsx
+++ b/src/VirtualLocalStorageContextProvider.jsx
@@ -15,6 +15,7 @@ export const VirtualLocalStorageContextProvider = ({ children }) => {
                     },
                 ],
                 lang: "english",
+                all_transactions: [],
             })
         )
     }

--- a/src/VirtualLocalStorageContextProvider.jsx
+++ b/src/VirtualLocalStorageContextProvider.jsx
@@ -7,7 +7,12 @@ export const VirtualLocalStorageContextProvider = ({ children }) => {
             "app_data",
             JSON.stringify({
                 profiles_seed: [
-                    { user_id: 0, jwt: undefined, is_active: true },
+                    {
+                        user_id: 0,
+                        jwt: undefined,
+                        is_active: true,
+                        max_sync_depth: 3,
+                    },
                 ],
                 lang: "english",
             })

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -52,7 +52,7 @@ var Login = () => {
                         ...i,
                         is_active: false,
                     })),
-                    { user_id, jwt, is_active: true },
+                    { user_id, jwt, is_active: true, max_sync_depth: 3 },
                 ],
             }))
             nav("/dashboard")

--- a/src/components/Register.jsx
+++ b/src/components/Register.jsx
@@ -49,7 +49,7 @@ export var Register = () => {
                             ...i,
                             is_active: false,
                         })),
-                        { user_id, jwt, is_active: true },
+                        { user_id, jwt, is_active: true, max_sync_depth: 3 },
                     ],
                 }))
             }

--- a/src/output.css
+++ b/src/output.css
@@ -945,12 +945,12 @@ video {
   padding-right: 0.5rem;
 }
 
-.pt-2 {
-  padding-top: 0.5rem;
-}
-
 .pr-3 {
   padding-right: 0.75rem;
+}
+
+.pt-2 {
+  padding-top: 0.5rem;
 }
 
 .text-center {


### PR DESCRIPTION
- working on #197 : fixed : now a union of discoverable transactions of multiple profiles is sent when syncing a websocket client. there is not ant duplicate transactions any more
- completed beta of making max_sync_depth system work
- SyncCentreWidget was extracted to DashboardParts - its now synced with everywhere using virtual local storage context
- little : moved apply_max_sync_depth to UH Core
- added support for caches. server wont any transaction that you have already inside disk or whatever
- added disk cache and it seems to be working as expected. some more improvements must be done.
- addressed an issue about local storage limit : it was found out that it needs approx 25 mil transactions to pass that limit! added a try catch. even if it happen there will not be any problem: just new writings to local storage will fail and those new changes will be discarded once page is reloaded.
